### PR TITLE
Separate into two distinct explainers

### DIFF
--- a/dash-events-explainer.md
+++ b/dash-events-explainer.md
@@ -1,0 +1,162 @@
+# Browser Handling of DASH Event Messages
+
+The aim of this proposal is to define browser-native handling of MPEG-DASH timed metadata events, which today is handled at the web application layer. MPEG DASH `emsg` events are included in MPEG CMAF, which has emerged as the common media delivery format in HLS and MPEG-DASH.
+
+The current approach for handling in-band event information, implemented by libraries such as [dash.js](https://github.com/Dash-Industry-Forum/dash.js/wiki) and [hls.js](https://github.com/video-dev/hls.js), is to parse the media segments in JavaScript to extract the events and construct `VTTCue` objects.
+
+On resource constrained devices such as smart TVs and streaming sticks, this leads to a significant performance penalty, which can have an impact on UI rendering updates if this is done on the UI thread (although we note the [proposal](https://github.com/wicg/media-source/blob/mse-in-workers-using-handle/mse-in-workers-using-handle-explainer.md) to make Media Source Extensions available to Worker contexts). There can also be an impact on the battery life of mobile devices. Given that the media segments will be parsed anyway by the user agent, parsing in JavaScript is an expensive overhead that could be avoided.
+
+Avoiding parsing in JavaScript is also important for low latency video streaming applications, where minimizing the time taken to pass media content through to the media element's playback buffer is essential.
+
+Instead of using `VTTCue`, a separate proposal introduces `DataCue` as a more appropriate cue API for timed metadata. See the [DataCue explainer](explaner.md) for details.
+
+## Use cases
+
+Many of the use cases are described in the [DataCue explainer](explainer.md).
+
+### Dynamic content insertion
+
+A media content provider wants to allow insertion of content, such as personalised video, local news, or advertisements, into a video media stream that contains the main program content. To achieve this, timed metadata is used to describe the points on the media timeline, known as splice points, where switching playback to inserted content is possible.
+
+[SCTE 35](https://scte-cms-resource-storage.s3.amazonaws.com/ANSI_SCTE-35-2019a-1582645390859.pdf) defines a data cue format for describing such insertion points. Use of these cues in MPEG-DASH streams is described in [SCTE 214-1](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-1%202016.pdf), [SCTE 214-2](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-2%202016.pdf), and [SCTE 214-3](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-3%202015.pdf). Use in HLS streams is described in SCTE-35 section 12.2.
+
+### Media player control messages
+
+MPEG-DASH defines several control messages for media streaming clients (e.g., libraries such as [dash.js](https://github.com/Dash-Industry-Forum/dash.js/wiki)). Control messages exist for several scenarios, such as:
+
+* The media player should refresh or update its copy of the manifest document (MPD)
+* The media player should make an HTTP request to a given URL for analytics purposes
+* The media presentation will end at a time earlier than expected
+
+These messages may be carried as in-band `emsg` events in the media container files.
+
+## Proposed API
+
+The proposed API is based on the existing [text track support](https://html.spec.whatwg.org/multipage/media.html#timed-text-tracks) in HTML and the [proposed `DataCue` API](explainer.md).
+
+> TODO: Add API summary
+
+As new `emsg` event types can be introduced from time to time, we propose to expose the raw binary `emsg` data for applications to parse. This avoids the need for browsers to natively understand the structure of the event messages.
+
+We will need to specify how to extract in-band timed metadata from the media container, and the structure in which the data is exposed via the `DataCue` interface. There are a couple of options for how to do this:
+
+1. We could update the existing [Sourcing In-band Media Resource Tracks from Media Containers into HTML](https://dev.w3.org/html5/html-sourcing-inband-tracks/) spec.
+
+2. We could produce a new set of specifications, following a registry approach with one specification per media format that describes the timed metadata details for that format, similar to the [Media Source Extensions Byte Stream Format Registry](https://www.w3.org/TR/mse-byte-stream-format-registry/). This could be based on [Sourcing In-band Media Resource Tracks from Media Containers into HTML](https://dev.w3.org/html5/html-sourcing-inband-tracks/).
+
+## Code examples
+
+> TODO: Needs updating: show how to subscribe to specific event streams, show how to set the dispatch mode.
+
+### Subscribing to receive in-band timed metadata cues
+
+This example shows how to add a `cuechange` handler that can be used to receive media-timed data and event cues.
+
+```javascript
+const video = document.getElementById('video');
+
+video.textTracks.addEventListener('addtrack', (event) => {
+  const textTrack = event.track;
+
+  if (textTrack.kind === 'metadata') {
+    textTrack.mode = 'hidden';
+
+    // See cueChangeHandler examples below
+    textTrack.addEventListener('cuechange', cueChangeHandler);
+  }
+});
+```
+
+### MPEG-DASH callback event handler
+
+```javascript
+const cueChangeHandler = (event) => {
+  const metadataTrack = event.target;
+  const activeCues = metadataTrack.activeCues;
+
+  for (let i = 0; i < activeCues.length; i++) {
+    const cue = activeCues[i];
+
+    // The UA delivers parsed message data for this message type
+    if (cue.type === 'urn:mpeg:dash:event:callback:2015' &&
+        cue.value.emsgValue === '1') {
+      const url = cue.value.data;
+      fetch(url).then(() => { console.log('Callback completed'); });
+    }
+  }
+};
+```
+
+### SCTE-35 dynamic content insertion cue handler
+
+This example shows how a web application can handle [SCTE 35](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-3%202015.pdf) cues, both in the case where the cues are parsed by the browser implementation, and where parsed by the web application.
+
+```javascript
+const cueChangeHandler = (event) => {
+  const metadataTrack = event.target;
+  const activeCues = metadataTrack.activeCues;
+
+  for (let i = 0; i < activeCues.length; i++) {
+    const cue = activeCues[i];
+
+    if (cue.type === 'urn:scte:scte35:2013:bin') {
+      // Parse the SCTE-35 message payload.
+      // parseSCTE35Data() is similar to Comcast's scte35.js library,
+      // adapted to take an ArrayBuffer as input.
+      // https://github.com/Comcast/scte35-js/blob/master/src/scte35.ts
+      const scte35Message = parseSCTE35Data(cue.value.data);
+
+      console.log(cue.startTime, cue.endTime, scte35Message.tableId, scte35Message.spliceCommandType);
+    }
+  }
+};
+```
+
+### Cue enter/exit handlers
+
+This example shows how a web application can use the proposed new `addcue` event to attach `enter` and `exit` handlers to each cue on the metadata track.
+
+```javascript
+// video.currentTime has reached the cue start time
+// through normal playback progression
+const cueEnterHandler = (event) => {
+  const cue = event.target;
+  console.log('cueEnter', cue.startTime, cue.endTime);
+};
+
+// video.currentTime has reached the cue end time
+// through normal playback progression
+const cueExitHandler = (event) => {
+  const cue = event.target;
+  console.log('cueExit', cue.startTime, cue.endTime);
+};
+
+// A cue has been parsed from the media container
+const addCueHandler = (event) => {
+  const cue = event.cue;
+
+  // Attach enter/exit event handlers
+  cue.onenter = cueEnterhandler;
+  cue.onexit = cueExitHandler;
+};
+
+const video = document.getElementById('video');
+
+video.textTracks.addEventListener('addtrack', (event) => {
+  const textTrack = event.track;
+
+  if (textTrack.kind === 'metadata') {
+    textTrack.mode = 'hidden';
+
+    textTrack.addEventListener('addcue', addCueHandler);
+  }
+});
+```
+
+## Considered alternatives
+
+> TODO
+
+## References
+
+This explainer is based on content from a [Note](https://w3c.github.io/me-media-timed-events/) written by the W3C Media and Entertainment Interest Group, and from a number of associated discussions, including the [TPAC breakout session on video metadata cues](https://github.com/w3c/strategy/issues/113#issuecomment-432971265). It is also closely related to the DASH-IF [DASH Player's Application Events and Timed Metadata Processing Models and APIs](https://dashif-documents.azurewebsites.net/Events/master/event.html) document.

--- a/explainer.md
+++ b/explainer.md
@@ -1,36 +1,20 @@
-# DataCue Explainer
+# DataCue
 
-## Introduction
+DataCue is a proposed web API to allow support for timed metadata, i.e., metadata information that is synchronized to audio or video media.
 
-HTTP Live Streaming (HLS) and MPEG Dynamic Adaptive Streaming over HTTP (MPEG-DASH) are the two main adaptive streaming formats in use on the web today. The media industry is coverging on the use of [MPEG Common Media Application Format (CMAF)](https://www.iso.org/standard/71975.html) as the common media delivery format. HLS, MPEG-DASH, and MPEG CMAF all support delivery of timed metadata, i.e., metadata information that is synchronized to the audio or video media. Timed metadata can be used to support use cases such as dynamic content replacement, ad insertion, or presentation of supplemental content alongside the audio or video, or more generally, making changes to a web page, or executing application code triggered from JavaScript events, at specific points on the media timeline of an audio or video media stream.
-
-The data may be carried either "in-band", meaning that they are delivered within the audio or video media container or multiplexed with the media stream, or "out-of-band", meaning that they are delivered externally to the media container or media stream. This explainer proposes bringing support for such timed metadata to the web platform.
+Timed metadata can be used to support use cases such as dynamic content replacement, ad insertion, or presentation of supplemental content alongside the audio or video, or more generally, making changes to a web page, or executing application code triggered from JavaScript events, at specific points on the media timeline of an audio or video media stream.
 
 ## Use cases
+
+Timed metadata can be used to support use cases such as dynamic content replacement, ad insertion, or presentation of supplemental content alongside the audio or video, or more generally, making changes to a web page, or executing application code triggered from JavaScript events, at specific points on the media timeline of an audio or video media stream. The following sections describe some specific use cases in more detail.
 
 ### Lecture recording with slideshow
 
 An HTML page contains title and information about the course or lecture, and two frames: a video of the lecturer in one and their slides in the other. Each timed metadata cue contains the URL of the slide to be presented, and the cue is active for the time range over which the slide should be visible.
 
-### Dynamic content insertion
-
-A media content provider wants to allow insertion of content, such as personalised video, local news, or advertisements, into a video media stream that contains the main program content. To achieve this, timed metadata is used to describe the points on the media timeline, known as splice points, where switching playback to inserted content is possible.
-
-[SCTE 35](https://scte-cms-resource-storage.s3.amazonaws.com/ANSI_SCTE-35-2019a-1582645390859.pdf) defines a data cue format for describing such insertion points. Use of these cues in MPEG-DASH streams is described in [SCTE 214-1](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-1%202016.pdf), [SCTE 214-2](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-2%202016.pdf), and [SCTE 214-3](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-3%202015.pdf). Use in HLS streams is described in SCTE-35 section 12.2.
-
-### Media player control messages
-
-MPEG-DASH defines several control messages for media streaming clients (e.g., libraries such as [dash.js](https://github.com/Dash-Industry-Forum/dash.js/wiki)). Control messages exist for several scenarios, such as:
-
-* The media player should refresh or update its copy of the manifest document (MPD)
-* The media player should make an HTTP request to a given URL for analytics purposes
-* The media presentation will end at a time earlier than expected
-
-These messages may be carried as in-band `emsg` events in the media container files.
-
 ### Media stream with video and synchronized graphics
 
-A content provider wants to provide synchronized graphical elements that may be rendered next to or on top of a video.
+A website wants to provide synchronized graphical elements that may be rendered next to or on top of a video.
 
 For example, in a talk show this could be a banner, shown in the lower third of the video, that displays the name of the guest. In a sports event, the graphics could show the latest lap times or current score, or highlight the location of the current active player. It could even be a full-screen overlay, to blend from one part of the program to another.
 
@@ -42,7 +26,7 @@ This use case requires frame accurate synchronization of the content being rende
 
 ### Synchronized map animations
 
-A user records footage with metadata, including geolocation, on a mobile video device, e.g., drone or dashcam, to share on the web alongside a map, e.g., OpenStreetMap.
+A user records footage with metadata, including geolocation, on a mobile video device such as a drone or dashcam, to share on the web alongside a map, e.g., OpenStreetMap.
 
 WebVMT is an open format for metadata cues, synchronized with audio or video media, that can be used to drive an online map rendered in a separate HTML element alongside the media element on the web page. The media playhead position controls presentation and animation of the map, e.g., pan and zoom, and allows annotations to be added and removed, e.g., markers, at specified times during media playback. Control can also be overridden by the user with the usual interactive features of the map at any time, e.g., zoom. Concrete examples are provided by the [tech demos at the WebVMT website](http://webvmt.org/demos).
 
@@ -54,25 +38,17 @@ It should be possible for search results to be represented as media in the user 
 
 > NOTE: Whether this use case requires any changes to the user agent or not is unclear without further investigation. If no changes are required, this capability should be demonstrated and the use case listed as a non-goal.
 
-## HTTP adaptive streaming
+## Event delivery
 
-HTTP adaptive streaming (HLS and MPEG-DASH) involves dividing the audio and video stream into small segments, each typically of a few seconds duration. Different encodings of the same content, known as representations, can be made available at varying quality levels (video resolution, bit rate), to allow a client application to select the most appropriate encoding for the playback device, as well as vary the bitrate in order to maintain continuous playback in response to changing network bandwidth conditions. These representations, and details of how to request the media segments are described in a manifest document.
+HTTP Live Streaming (HLS) and MPEG Dynamic Adaptive Streaming over HTTP (MPEG-DASH) are the two main adaptive streaming formats in use on the web today. The media industry is coverging on the use of [MPEG Common Media Application Format (CMAF)](https://www.iso.org/standard/71975.html) as the common media delivery format. HLS, MPEG-DASH, and MPEG CMAF all support delivery of timed metadata, i.e., metadata information that is synchronized to the audio or video media.
 
-Some user agents (notably Safari and HbbTV) include native support for adaptive streaming playback, rather than through use of [Media Source Extensions](https://www.w3.org/TR/media-source/). In these cases, we need the user agent to expose to web applications any timed metadata cues that are carried either in-band with the media, or out-of-band via the manifest document.
+Both HLS and MPEG-DASH use a combination of encoded media files and manifest files that identify the available streams their respective URLs.
 
-Other user agents support adaptive streaming playback via [Media Source Extensions](https://www.w3.org/TR/media-source/). Here, a web application reads the manifest document, then requests the media segments and uses Media Source Extensions to pass the media to the user agent for playback. With these user agents, out-of-band timed metadata cues (i.e., those carried in the manifest document) must be created by the web application. In-band timed metadata cues may be created either by the web application, by parsing the media content before passing it to MSE using `appendBuffer()`, or by the user agent when it receives and decodes the media content from the web application.
+Some user agents (notably Safari and HbbTV) include native support for adaptive streaming playback, rather than through use of [Media Source Extensions](https://www.w3.org/TR/media-source/). In these cases, we need the user agent to expose to web applications any timed metadata cues that are carried either in-band with the media (i.e., delivered within the audio or video media container or multiplexed with the media stream), or out-of-band via the manifest document.
 
-## In-band timed metadata processing
+## Proposed API
 
-The exact set of in-band timed metadata formats that we would aim to support is to be decided. MPEG DASH `emsg` events are a requirement, due to their inclusion in MPEG CMAF. We expect to discuss which other events to standardise, particularly HLS timed metadata, as part of the incubation work.
-
-Where message types are widely supported (e.g., the MPEG-DASH specific events described above), the DataCue API would present the data in parsed form, so that it's convenient for web applications to access. Other message types, such as application-specific messages, would not be parsed directly by the user agent and instead would be presented to the web application in raw binary form.
-
-In addition to specifying the `DataCue` API, we also need to specify how to extract in-band timed metadata from the media container, and the structure in which the data is exposed via the `DataCue` interface. This could be done either in the DataCue spec, or in a separate set of specifications, following a registry approach with one specification per media format that describes the timed metadata details for that format, similar to the [Media Source Extensions Byte Stream Format Registry](https://www.w3.org/TR/mse-byte-stream-format-registry/). Another approach could be to update [Sourcing In-band Media Resource Tracks from Media Containers into HTML](https://dev.w3.org/html5/html-sourcing-inband-tracks/), either in its current form as a single document, or splitting it by media format and adding a registry.
-
-## Proposed API and example code
-
-The proposed API is based on the existing text track support in HTML and WebKit's `DataCue`. This extends the [HTML5 `DataCue` API](https://www.w3.org/TR/2018/WD-html53-20181018/semantics-embedded-content.html#text-tracks-exposing-inband-metadata) with two attributes to support non-text metadata, `type` and `value` that replace the existing `data` attribute. We also add a constructor that allows these fields to be initialized by web applications.
+The proposed API is based on the existing [text track support](https://html.spec.whatwg.org/multipage/media.html#timed-text-tracks) in HTML and WebKit's `DataCue`. This extends the [HTML5 `DataCue` API](https://www.w3.org/TR/2018/WD-html53-20181018/semantics-embedded-content.html#text-tracks-exposing-inband-metadata) with two attributes to support non-text metadata, `type` and `value` that replace the existing `data` attribute. We also add a constructor that allows these fields to be initialized by web applications.
 
 ```webidl
 interface DataCue : TextTrackCue {
@@ -87,13 +63,13 @@ interface DataCue : TextTrackCue {
 };
 ```
 
-`value`: Contains the message data, in either parsed or unparsed form. Unparsed data is exposed as an `ArrayBuffer`, and it is up to the web application to parse the data. For parsed data, the content and structure of the `value` field is expected to be in a more convenient form for web applications to use than an `ArrayBuffer`, such as a string, or an object. The `value` may be `undefined` if the message type contains no message data.
+`value`: Contains the message data, which may be in any arbitrary data structure.
 
-`type`: A string that identifies the structure and content of the cue's `value`.
+`type`: A string that can be used to identify the structure and content of the cue's `value`.
 
-### Mapping to HLS timed metadata
+## User agent-generated DataCue instances
 
-WebKit supports the several kinds of timed metadata, using the following `type` values:
+Some user agents may automatically generate `DataCue` timed metadata cues while playing media. For example, WebKit supports several kinds of timed metadata in HLS streams, using the following `type` values:
 
 | Type                       | Purpose             |
 | -------------------------- | ------------------- |
@@ -103,134 +79,34 @@ WebKit supports the several kinds of timed metadata, using the following `type` 
 | `org.mp4ra`                | MPEG-4 metadata     |
 | `org.id3`                  | ID3 metadata        |
 
-In each case, the `value` attribute contains the parsed message data.
-
 Additional information about existing support in WebKit can be found in [the IDL](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/html/track/DataCue.idl) and in [this layout test](https://trac.webkit.org/browser/webkit/trunk/LayoutTests/http/tests/media/track-in-band-hls-metadata.html), which loads various types of ID3 metadata from an HLS stream.
 
-### Mapping to MPEG-DASH in-band emsg events
+This proposal does not seek to standardize UA-generated `DataCue` schemas, but the proposed API is intended to support this usage.
 
-The `emsg` data structure is defined in section 5.10.3.3 of the [MPEG-DASH spec](https://www.iso.org/standard/79329.html).
-Use of `emsg` within CMAF media is defined in section 7.4.5 of the [MPEG CMAF spec](https://www.iso.org/standard/79106.html) ([public draft](https://mpeg.chiariglione.org/sites/default/files/files/standards/parts/docs/w16186.zip)).
+Other proposals may be developed for this purpose, e.g., for the above or MPEG-DASH timed metadata events.
 
-There are two versions in use, version 0 and 1:
+## Code examples
 
-```
-aligned(8) class DASHEventMessageBox extends FullBox ('emsg', version, flags = 0) {
-  if (version == 0) {
-    string scheme_id_uri;
-    string value;
-    unsigned int(32) timescale_v0;
-    unsigned int(32) presentation_time_delta;
-    unsigned int(32) event_duration;
-    unsigned int(32) id;
-  } else if (version == 1) {
-    unsigned int(32) timescale_v1;
-    unsigned int(64) presentation_time;
-    unsigned int(32) event_duration;
-    unsigned int(32) id;
-    string scheme_id_uri;
-    string value;
-  }
-  unsigned int(8) message_data[];
-}
-```
-
-| DataCue attribute     | emsg value                                                                                                   |
-|-----------------------|--------------------------------------------------------------------------------------------------------------|
-| `DOMString id`        | `id`                                                                                                         |
-| `double startTime`    | Computed from `timescale` and `presentation_time_delta` or `presentation_time` (see Note)                    |
-| `double endTime`      | Computed from `timescale`, `presentation_time_delta` or `presentation_time`, and `event_duration` (see Note) |
-| `boolean pauseOnExit` | `false`                                                                                                      |
-| `any value`           | Object containing data from the `message_data` and `value` emsg fields (see below)                           |
-| `DOMString type`      | `scheme_id_uri`                                                                                              |
-
-**Note:** The `timescale` value provides the timescale for the `presentation_time_delta` and `event_duration` fields, in ticks per second. Refer to [CMAF](https://mpeg.chiariglione.org/sites/default/files/files/standards/parts/docs/w16186.zip) for details on the interpretation of these fields.
-
-The `DataCue.value` field is an object containing the following attributes:
-
-| Attribute             | emsg value      | Description                                                                                                                                          |
-|-----------------------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `any data`            | `message_data`  | The message data, either in unparsed form as an `ArrayBuffer` or in parsed form as a string, object, or other type as appropriate for the given data |
-| `DOMString emsgValue` | `value`         | Specifies the value for the event. The value space and semantics must be defined by the owners of the scheme identified by the `scheme_id_uri`       |
-
-### Mapping to MPEG-DASH MPD events
-
-Timed event information may also be carried in the manifest document.
-
-> TODO: Add example to show how a web app would construct a DataCue from an MPD event
-
-## Examples
-
-### Subscribing to receive in-band timed metadata cues
-
-This example shows how to add a `cuechange` handler that can be used to receive media-timed data and event cues.
+### Create an unbounded DataCue with geolocation data
 
 ```javascript
 const video = document.getElementById('video');
-
-video.textTracks.addEventListener('addtrack', (event) => {
-  const textTrack = event.track;
-
-  if (textTrack.kind === 'metadata') {
-    textTrack.mode = 'hidden';
-
-    // See cueChangeHandler examples below
-    textTrack.addEventListener('cuechange', cueChangeHandler);
-  }
-});
+const textTrack = video.addtrack('metadata');
+// Create a cue from 5 secs to end of media
+const data = { "moveto": { "lat": 51.504362, "lng": -0.076153 } };
+const cue = new DataCue(5.0, Infinity, data, 'org.webvmt');
+textTrack.addCue(cue);
 ```
 
-### MPEG-DASH callback event handler
+### Create a DataCue from an in-band DASH 'emsg' box
 
 ```javascript
-const cueChangeHandler = (event) => {
-  const metadataTrack = event.target;
-  const activeCues = metadataTrack.activeCues;
+// Parse the media segment to extract timed metadata cues
+// contained in DASH 'emsg' boxes
+function extractEmsgBoxes(mediaSegment) {
+  // etc.
+}
 
-  for (let i = 0; i < activeCues.length; i++) {
-    const cue = activeCues[i];
-
-    // The UA delivers parsed message data for this message type
-    if (cue.type === 'urn:mpeg:dash:event:callback:2015' &&
-        cue.value.emsgValue === '1') {
-      const url = cue.value.data;
-      fetch(url).then(() => { console.log('Callback completed'); });
-    }
-  }
-};
-```
-
-### SCTE-35 dynamic content insertion cue handler
-
-This example shows how a web application can handle [SCTE 35](https://scte-cms-resource-storage.s3.amazonaws.com/Standards/ANSI_SCTE%20214-3%202015.pdf) cues, both in the case where the cues are parsed by the browser implementation, and where parsed by the web application.
-
-```javascript
-const cueChangeHandler = (event) => {
-  const metadataTrack = event.target;
-  const activeCues = metadataTrack.activeCues;
-
-  for (let i = 0; i < activeCues.length; i++) {
-    const cue = activeCues[i];
-
-    if (cue.type === 'urn:scte:scte35:2013:bin') {
-      // Parse the SCTE-35 message payload.
-      // parseSCTE35Data() is similar to Comcast's scte35.js library,
-      // adapted to take an ArrayBuffer as input.
-      // https://github.com/Comcast/scte35-js/blob/master/src/scte35.ts
-      const scte35Message = (cue.value.data instanceof ArrayBuffer) ?
-        parseSCTE35Data(cue.value.data) : cue.value.data;
-
-      console.log(cue.startTime, cue.endTime, scte35Message.tableId, scte35Message.spliceCommandType);
-    }
-  }
-};
-```
-
-### Cue enter/exit handlers
-
-This example shows how a web application can use the proposed new `addcue` event to attach `enter` and `exit` handlers to each cue on the metadata track.
-
-```javascript
 // video.currentTime has reached the cue start time
 // through normal playback progression
 const cueEnterHandler = (event) => {
@@ -245,68 +121,55 @@ const cueExitHandler = (event) => {
   console.log('cueExit', cue.startTime, cue.endTime);
 };
 
-// A cue has been parsed from the media container
-const addCueHandler = (event) => {
-  const cue = event.cue;
+function createDataCues(events, textTrack) {
+  events.forEach(event => {
+    const cue = new DataCue(
+      event.startTime,
+      event.endTime,
+      event.payload,
+      event.schemeIdUri
+    );
 
-  // Attach enter/exit event handlers
-  cue.onenter = cueEnterhandler;
-  cue.onexit = cueExitHandler;
-};
+    // Attach enter/exit event handlers
+    cue.onenter = cueEnterhandler;
+    cue.onexit = cueExitHandler;
+
+    textTrack.addCue(cue);
+  });
+}
+
+// Append the segment to the MSE SourceBuffer
+function appendSegment(segment) {
+  // etc.
+  sourceBuffer.appendBuffer(segment);
+}
 
 const video = document.getElementById('video');
+const textTrack = video.addtrack('metadata');
 
-video.textTracks.addEventListener('addtrack', (event) => {
-  const textTrack = event.track;
+// Fetch a media segment, parse and create DataCue instances,
+// and append the segment for playback using Media Source Extensions.
+fetch('/media-segments/12345.m4s')
+  .then(response => response.arrayBuffer())
+  .then(buffer => {
+    const events = extractEmsgBoxes(buffer);
+    createDataCues(events, textTrack)
 
-  if (textTrack.kind === 'metadata') {
-    textTrack.mode = 'hidden';
-
-    textTrack.addEventListener('addcue', addCueHandler);
-  }
-});
+    appendSegment(buffer);
+  });
 ```
 
-### Out-of-band timed metadata
+### Create a DataCue from a DASH MPD event
 
-> TODO: Add example code showing how a web application can construct `DataCue` objects with start and end times, event type, and data payload. For `emsg` events, the event type is defined by the `id` and (optional) `value` fields.
-
-### Unknown end time support for streamed cues
-
-A user wants to display content which is synchronized to a web media object and remains visible from the cue start time until the media finishes playing. For example, a common use case for [WebVMT](https://w3c.github.io/sdw/proposals/geotagging/webvmt/) is to add a map annotation cue which persists for the media duration. In the case of live streaming, the end of the media timeline is unknown and there is currently no value of `TextTrackCue.endTime` that can represent this.
-
-It is proposed that a `TextTrackCue.endTime` value of `Infinity` be used to represent the end of media time. This is consistent with the approach used by the `HTMLMediaElement` [`duration`](https://html.spec.whatwg.org/multipage/media.html#offsets-into-the-media-resource) attribute, where `Infinity` represents the duration of an unbounded stream.
-
-`TextTrackCue.endTime` is declared as a [`double`](https://heycam.github.io/webidl/#idl-double), which excludes non-finite values, so we propose to change this to [`unrestricted double`](https://heycam.github.io/webidl/#idl-unrestricted-double).
-
-```javascript
-const video = document.getElementById('video');
-const track = video.addtrack('metadata');
-// Create a cue from 5 secs to end of media
-const data = { "moveto": { "lat": 51.504362, "lng": -0.076153 } };
-const cue = new DataCue(5.0, Infinity, data, 'org.webvmt');
-track.addCue(cue);
-```
-
-### Event triggering
-
-> TODO: Add example code showing how a web application can be notified of in-band events as they are parsed from the media container or media stream.
-
-> TODO: Add example code showing how a web application can respond to events (either in-band or out-of-band) as media playback reaches their position on the media timeline.
+> TODO: Add example code showing how a web application can construct `DataCue` objects with start and end times, event type, and data payload from a DASH MPD event, where the MPD is parsed by the web application
 
 ## Considered alternatives
 
 ### WebVTT metadata cues
 
-Web applications today can use WebVTT metadata cues (the [VTTCue](https://www.w3.org/TR/webvtt1/#vttcue) API) to schedule out-of-band timed metadata events by serializing the timed metadata to a string format (JSON, for example) when creating the cue, and deserializing the data when the cue's `onenter` event is fired. Although this works in practice, the serialization/deserialization step should be unnecessary. It also does not support in-band timed metadata.
+Web applications today can use WebVTT metadata cues (the [`VTTCue`](https://www.w3.org/TR/webvtt1/#vttcue) API) to schedule timed metadata events by serializing the data to a string format (JSON, for example) when creating the cue, and deserializing the data when the cue's `onenter` event is fired. Although this works in practice, `DataCue` avoids the need for the serialization/deserialization steps.
 
-### Application level stream parsing
-
-The current approach for handling in-band event information, implemented by libraries such as [dash.js](https://github.com/Dash-Industry-Forum/dash.js/wiki) and [hls.js](https://github.com/video-dev/hls.js), is to parse the media segments in JavaScript to extract the events and construct `VTTCue` objects.
-
-On resource constrained devices such as smart TVs and streaming sticks, this leads to a significant performance penalty, which can have an impact on UI rendering updates if this is done on the UI thread (although we note the [proposal](https://github.com/wicg/media-source/blob/mse-in-workers-using-handle/mse-in-workers-using-handle-explainer.md) to make Media Source Extensions available to Worker contexts). There can also be an impact on the battery life of mobile devices. Given that the media segments will be parsed anyway by the user agent, parsing in JavaScript is an expensive overhead that could be avoided.
-
-Avoiding parsing in JavaScript is also important for low latency video streaming applications, where minimizing the time taken to pass media content through to the media element's playback buffer is essential.
+`DataCue` is also sementically consistent with timed metadata use cases, where `VTTCue` is designed for subtitles and captions. `VTTCue` contains a lot of API surface related to caption layout and presentation, which are not relevant to timed metadata cues.
 
 ## Event synchronization
 


### PR DESCRIPTION
See #31 for context. This PR rewrites the current explainer into two separate explainers:

- DataCue API
- Browser Handling of DASH Event Messages

